### PR TITLE
Handle whitespace in s_dir

### DIFF
--- a/play-anything.sh
+++ b/play-anything.sh
@@ -60,7 +60,7 @@ build_pkg_arch(){
 	tar -cf - .PKGINFO * | xz -0 -c -z - > "${desc}-${vers}.pkg.tar.xz"
 	mv "${desc}-${vers}.pkg.tar.xz" "${s_dir}/${desc}-${vers}.pkg.tar.xz"
 	rm -rf "${dir}" "${PKG_TMPDIR}"
-    cd ${s_dir}
+	cd "${s_dir}"
 }
 
 


### PR DESCRIPTION
Wrapped ${s_dir} in double quotes, because otherwise the script won't work for directories with a whitespace in their name